### PR TITLE
Added support for earlier OpenWRT versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ ENV/
 .idea/
 .vscode/settings.json
 config.py
+
+#vscode 
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ ENV/
 
 # pycharm
 .idea/
+.vscode/settings.json
+config.py

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Features
 
 -  Allows you to use the Luci RPC interface to fetch connected devices
    on your OpenWrt based router.
--  Supports 17.X & 18.X or newer releases of OpenWrt.
+-  Supports 15.X & 17.X & 18.X or newer releases of OpenWrt.
 
 
 Development

--- a/openwrt_luci_rpc/openwrt_luci_rpc.py
+++ b/openwrt_luci_rpc/openwrt_luci_rpc.py
@@ -64,9 +64,11 @@ class OpenWrtLuciRPC:
         :return: tuple, with True if legacy and the URL to
                 use to lookup devices
         """
-        rcp_sys_version_call = Constants.LUCI_RPC_SYS_PATH.format(self.host_api_url), "exec"
+        rcp_sys_version_call = Constants.\
+            LUCI_RPC_SYS_PATH.format(self.host_api_url), "exec"
 
-        content = self._call_json_rpc(*rcp_sys_version_call, "cat /etc/openwrt_version")
+        content = self._call_json_rpc(*rcp_sys_version_call,
+                                      "cat /etc/openwrt_version")
         self.owrt_version = version.parse(content.strip())
 
         rpc_sys_arp_call = Constants.\
@@ -79,7 +81,6 @@ class OpenWrtLuciRPC:
             return True, rpc_sys_arp_call
         else:
             return False, rpc_ip_call
-
 
     def get_all_connected_devices(self, only_reachable, wlan_interfaces):
         """

--- a/openwrt_luci_rpc/openwrt_luci_rpc.py
+++ b/openwrt_luci_rpc/openwrt_luci_rpc.py
@@ -74,7 +74,8 @@ class OpenWrtLuciRPC:
             LUCI_RPC_SYS_PATH.format(self.host_api_url), "exec"
 
         try:
-            content = self._call_json_rpc(*rcp_sys_version_call,
+            content = self._call_json_rpc(rcp_sys_version_call[0],
+                                          rcp_sys_version_call[1],
                                           "cat /etc/openwrt_version")
 
             if content is None:

--- a/openwrt_luci_rpc/openwrt_luci_rpc.py
+++ b/openwrt_luci_rpc/openwrt_luci_rpc.py
@@ -147,6 +147,10 @@ class OpenWrtLuciRPC:
         """Perform one JSON RPC operation."""
         data = json.dumps({'method': method, 'params': args})
 
+        # pass token to make it work with version < 17
+        if self.token is not None:
+            url += "?auth=" + self.token
+
         log.info("_call_json_rpc : %s" % url)
         res = self.session.post(url,
                                 data=data,

--- a/tests/test_openwrt_15.py
+++ b/tests/test_openwrt_15.py
@@ -9,8 +9,14 @@ from openwrt_luci_rpc.openwrt_luci_rpc import utilities, OpenWrtLuciRPC
 from openwrt_luci_rpc.constants import Constants
 
 class TestOpenwrt15LuciRPC(unittest.TestCase):
-    def testLogin(self):
-        device = OpenWrtLuciRPC(config.host, config.username, config.password, config.is_https)
+    def testDiscover(self):
+        router = OpenWrtLuciRPC(config.host, config.username, config.password, config.is_https)
+
+        devices = router.get_all_connected_devices(False, False)
+        assert devices is not None
+
+
+
 
 
 if __name__ == '__main__':

--- a/tests/test_openwrt_15.py
+++ b/tests/test_openwrt_15.py
@@ -16,8 +16,5 @@ class TestOpenwrt15LuciRPC(unittest.TestCase):
         assert devices is not None
 
 
-
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_openwrt_15.py
+++ b/tests/test_openwrt_15.py
@@ -4,16 +4,18 @@
 """Tests for `openwrt_luci_rpc` package."""
 
 import unittest
-import config
+import os
 from openwrt_luci_rpc.openwrt_luci_rpc import OpenWrtLuciRPC
 
 
 class TestOpenwrt15LuciRPC(unittest.TestCase):
 
     def testDiscover(self):
-        router = OpenWrtLuciRPC(config.host, config.username,
-                                config.password, config.is_https)
+        assert "HOST" in os.environ
+        assert "USER" in os.environ
+        assert "PASSWORD" in os.environ
 
+        router = OpenWrtLuciRPC(os.getenv("HOST"), os.getenv("USER"), os.getenv("PASSWORD"), os.getenv("HTTPS", "False") == "True")
         devices = router.get_all_connected_devices(False, False)
         assert devices is not None
 

--- a/tests/test_openwrt_15.py
+++ b/tests/test_openwrt_15.py
@@ -10,15 +10,21 @@ from openwrt_luci_rpc.openwrt_luci_rpc import OpenWrtLuciRPC
 
 class TestOpenwrt15LuciRPC(unittest.TestCase):
 
-    def testDiscover(self):
-        # HOST, USER, PASSWORD,[HTTPS] must be in env variables in order to run the test
-        assert "HOST" in os.environ
-        assert "USER" in os.environ
-        assert "PASSWORD" in os.environ
+    def setUp(self):
+        """Set up test fixtures, if any."""
 
-        router = OpenWrtLuciRPC(os.getenv("HOST"), os.getenv("USER"), os.getenv("PASSWORD"), os.getenv("HTTPS", "False") == "True")
-        devices = router.get_all_connected_devices(False, False)
-        assert devices is not None
+    def tearDown(self):
+        """Tear down test fixtures, if any."""
+
+    # def testDiscover(self):
+        # HOST, USER, PASSWORD,[HTTPS] must be in env variables in order to run the test
+        # assert "HOST" in os.environ
+        # assert "USER" in os.environ
+        # assert "PASSWORD" in os.environ
+
+        # router = OpenWrtLuciRPC(os.getenv("HOST"), os.getenv("USER"), os.getenv("PASSWORD"), os.getenv("HTTPS", "False") == "True")
+        # devices = router.get_all_connected_devices(False, False)
+        # assert devices is not None
 
 
 if __name__ == '__main__':

--- a/tests/test_openwrt_15.py
+++ b/tests/test_openwrt_15.py
@@ -5,12 +5,14 @@
 
 import unittest
 import config
-from openwrt_luci_rpc.openwrt_luci_rpc import utilities, OpenWrtLuciRPC
-from openwrt_luci_rpc.constants import Constants
+from openwrt_luci_rpc.openwrt_luci_rpc import OpenWrtLuciRPC
+
 
 class TestOpenwrt15LuciRPC(unittest.TestCase):
+
     def testDiscover(self):
-        router = OpenWrtLuciRPC(config.host, config.username, config.password, config.is_https)
+        router = OpenWrtLuciRPC(config.host, config.username,
+                                config.password, config.is_https)
 
         devices = router.get_all_connected_devices(False, False)
         assert devices is not None

--- a/tests/test_openwrt_15.py
+++ b/tests/test_openwrt_15.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `openwrt_luci_rpc` package."""
+
+import unittest
+import config
+from openwrt_luci_rpc.openwrt_luci_rpc import utilities, OpenWrtLuciRPC
+from openwrt_luci_rpc.constants import Constants
+
+class TestOpenwrt15LuciRPC(unittest.TestCase):
+    def testLogin(self):
+        device = OpenWrtLuciRPC(config.host, config.username, config.password, config.is_https)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_openwrt_15.py
+++ b/tests/test_openwrt_15.py
@@ -11,6 +11,7 @@ from openwrt_luci_rpc.openwrt_luci_rpc import OpenWrtLuciRPC
 class TestOpenwrt15LuciRPC(unittest.TestCase):
 
     def testDiscover(self):
+        # HOST, USER, PASSWORD,[HTTPS] must be in env variables in order to run the test
         assert "HOST" in os.environ
         assert "USER" in os.environ
         assert "PASSWORD" in os.environ

--- a/tests/test_openwrt_luci_rpc.py
+++ b/tests/test_openwrt_luci_rpc.py
@@ -5,7 +5,6 @@
 
 
 import unittest
-import requests
 from unittest.mock import Mock, patch
 
 from openwrt_luci_rpc import OpenWrtRpc
@@ -71,4 +70,3 @@ class TestOpenwrtLuciRPC(unittest.TestCase):
         assert data['_name'] == "cfg07ee1"
         assert data['_type'] == "host"
         assert data['ip'] == "192.168.1.124"
-

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,10 @@ commands = flake8 openwrt_luci_rpc
 deps = pytest
 setenv =
     PYTHONPATH = {toxinidir}
+passenv = HOST 
+          USER
+          PASSWORD
+          HTTPS
 
 commands = python setup.py test
 


### PR DESCRIPTION
I wanted to add support for my ChaosCalmer-basted router. 
To do that I passed the token in the url instead of using session cookies, this way should be compatible with both new and old openwrt versions.

I have also rewritten the _determine_if_legacy_version method, now it checks the version by checking the /etc/openwrt_version file and stores the version in a class attribute.

Things that need to be checked:
- We should see if /etc/openwrt_version is readable from non-root user and if non-root users can use the exec command. In my case the file's permissions are set to 644 so it should be readable but I cannot confirm
- Please check if discovery still works in newer versions, I have only this router which has 15.05.1

I hope people with older routers will be able to use this in home assistant.
Sorry for my english, it is not my native language

Fixes #25
