### PR TITLE
fix: include packaging in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['Click>=6.0', 'requests==2.21.0']
+requirements = ['Click>=6.0', 'requests==2.21.0', 'packaging==19.1']
 
 setup_requirements = [ ]
 


### PR DESCRIPTION
bug came up in home-assistant/home-assistant#26215

'packaging' should be in requirements.