### PR TITLE
Add option to disable HTTPS verification

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,5 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* `Miroslav Zdrale`_
+.. _`Miroslav Zdrale`: https://github.com/mzdrale

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -103,3 +103,10 @@ History
 
 * Adding packaging dependancy.
 
+1.1.2 (2019-10-11)
+------------------
+
+* Add option to enable or disable HTTPS verification.
+* Suppress "InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised." warnings.
+* Reduce number of info log messages.
+* Minor code clean-up to address flake8 warnings.

--- a/openwrt_luci_rpc/__init__.py
+++ b/openwrt_luci_rpc/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Finbarr Brady"""
 __email__ = 'fbradyirl@github.io'
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 
 from .openwrt_luci_rpc import OpenWrtLuciRPC
 from .constants import Constants
@@ -18,14 +18,18 @@ class OpenWrtRpc:
     def __init__(self, host_url=Constants.DEFAULT_LOCAL_HOST,
                  username=Constants.DEFAULT_USERNAME,
                  password=Constants.DEFAULT_PASSWORD,
-                 is_https=Constants.DEFAULT_HTTPS):
+                 is_https=Constants.DEFAULT_HTTPS,
+                 verify_https=Constants.DEFAULT_VERIFY_HTTPS):
         """
         Initiate an instance with a default local ip (192.168.1.1)
         :param host_url: string - host url. Defaults to 192.168.1.1
         :param username: string - username. Defaults to root
         :param password: string - password. Default is blank
+        :param is_https: boolean - use https? Default is false
+        :param verify_https: boolean - verify https? Default is true
         """
-        self.router = OpenWrtLuciRPC(host_url, username, password, is_https)
+        self.router = OpenWrtLuciRPC(host_url, username, password,
+                                     is_https, verify_https)
 
     def is_logged_in(self):
         """Returns true if a token has been aquired"""

--- a/openwrt_luci_rpc/constants.py
+++ b/openwrt_luci_rpc/constants.py
@@ -5,6 +5,7 @@ class Constants:
     DEFAULT_PASSWORD = ""
     DEFAULT_TIMEOUT = 30
     DEFAULT_HTTPS = False
+    DEFAULT_VERIFY_HTTPS = True
     DEFAULT_ONLY_REACH = True
     DEFAULT_WLAN_IF = ['wlan0-1']
 

--- a/tests/test_openwrt_15.py
+++ b/tests/test_openwrt_15.py
@@ -18,12 +18,19 @@ class TestOpenwrt15LuciRPC(unittest.TestCase):
 
     @unittest.skip("unskip this to test using env vars")
     def testDiscover(self):
-        # HOST, USER, PASSWORD,[HTTPS] must be in env variables in order to run the test
+        # HOST, USER, PASSWORD,[HTTPS] must be in env variables in order
+        # to run the test
         assert "HOST" in os.environ
         assert "USER" in os.environ
         assert "PASSWORD" in os.environ
 
-        router = OpenWrtLuciRPC(os.getenv("HOST"), os.getenv("USER"), os.getenv("PASSWORD"), os.getenv("HTTPS", "False") == "True")
+        router = OpenWrtLuciRPC(
+                    os.getenv("HOST"),
+                    os.getenv("USER"),
+                    os.getenv("PASSWORD"),
+                    os.getenv("HTTPS", "False") == "True",
+                    os.getenv("VERIFY_HTTPS", "False") == "True",
+                )
         devices = router.get_all_connected_devices(False, False)
         assert devices is not None
 

--- a/tests/test_openwrt_luci_rpc.py
+++ b/tests/test_openwrt_luci_rpc.py
@@ -47,7 +47,10 @@ class TestOpenwrtLuciRPC(unittest.TestCase):
         mock_post.return_value.json.return_value = json_result
 
         runner = OpenWrtRpc()
-        assert runner.router.host_api_url == '{}://{}'.format("http", Constants.DEFAULT_LOCAL_HOST)
+        assert runner.router.host_api_url == '{}://{}'.format(
+                    "http",
+                    Constants.DEFAULT_LOCAL_HOST
+                )
         assert runner.router.username == Constants.DEFAULT_USERNAME
         assert runner.router.password == Constants.DEFAULT_PASSWORD
 


### PR DESCRIPTION
Hi @fbradyirl,

Thanks for writing this package.
I'm using it with Home Assistant with HTTPS and it didn't work because SSL verification failed. So I added option to disable SSL verification. Also reduced number of info log messages, to avoid spamming Home Assistant log every few seconds. From my experience, Home Assistant maintainers don't like that. :)
I'm ready to open Home Assistant PR as soon as you accept my PR and release new version. I mean I will do that _if_ you accept my changes. :)

Best,
Miroslav