### PR TITLE
Support newer openwrt snapshot versions

### DIFF
--- a/openwrt_luci_rpc/openwrt_luci_rpc.py
+++ b/openwrt_luci_rpc/openwrt_luci_rpc.py
@@ -124,7 +124,7 @@ class OpenWrtLuciRPC:
             LUCI_RPC_IP_PATH.format(
                 self.host_api_url), 'neighbors', {"family": 4}
 
-        if self.owrt_version != version.parse("snapshot") and self.owrt_version < version.parse("18.06"):  # noqa: E501
+        if utilities.is_legacy_version(self.owrt_version):
             return True, rpc_sys_arp_call
         else:
             return False, rpc_ip_call

--- a/openwrt_luci_rpc/utilities.py
+++ b/openwrt_luci_rpc/utilities.py
@@ -1,4 +1,5 @@
 from .constants import Constants
+from packaging import version
 import logging
 
 log = logging.getLogger(__name__)
@@ -36,3 +37,10 @@ def get_hostname_from_dhcp(dhcp_result, mac):
             return host[0]['name']
 
     return None
+
+
+def is_legacy_version(owrt_version):
+    return (
+        owrt_version != version.parse("snapshot") and
+        owrt_version < version.parse("18.06")
+    )

--- a/openwrt_luci_rpc/utilities.py
+++ b/openwrt_luci_rpc/utilities.py
@@ -41,6 +41,6 @@ def get_hostname_from_dhcp(dhcp_result, mac):
 
 def is_legacy_version(owrt_version):
     return (
-        owrt_version != version.parse("snapshot") and
+        "snapshot" not in owrt_version.public and
         owrt_version < version.parse("18.06")
     )

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `openwrt_luci_rpc` package."""
+
+
+import unittest
+from openwrt_luci_rpc.utilities import is_legacy_version
+from packaging import version
+
+
+class TestOpenwrtLuciRPC(unittest.TestCase):
+    """Tests for `openwrt_luci_rpc` package."""
+
+    def setUp(self):
+        """Set up test fixtures, if any."""
+
+    def tearDown(self):
+        """Tear down test fixtures, if any."""
+
+    def test_is_legacy_version(self):
+        """Test comparing versions works as expected."""
+
+        assert is_legacy_version(version.parse("15.05")) is True
+        assert is_legacy_version(version.parse("15.05.1")) is True
+        assert is_legacy_version(version.parse("17.01")) is True
+        assert is_legacy_version(version.parse("17.01.6")) is True
+
+        assert is_legacy_version(version.parse("18.06")) is False
+        assert is_legacy_version(version.parse("18.06.9")) is False
+        assert is_legacy_version(version.parse("19.07.7")) is False
+
+        assert is_legacy_version(version.parse("snapshot")) is False
+        assert is_legacy_version(version.parse("21.02-snapshot")) is False


### PR DESCRIPTION
This PR adds support for new snapshot versions like `21.02-snapshot`