### PR TITLE
Fix tox in github actions and also test py38

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py37, flake8
+envlist = py37, py38, flake8
 
-[travis]
+[gh-actions]
 python =
     3.7: py37
+    3.8: py38
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
Without this change, tox does nothing in github actions jobs: https://github.com/fbradyirl/openwrt-luci-rpc/pull/45#issuecomment-791915919

And this PR also tests with python 3.8 which is the [currently supported version by Home Assistant](https://www.home-assistant.io/installation/linux#install-home-assistant-core).