### PR TITLE
Also trigger the Github Actions workflow on push of tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,16 @@
 name: Python package
 
 on:
-  # Trigger the workflow on push or pull request, but only for the master branch
   push:
+    tags:
+      # Trigger the workflow on push of tags
+      - '*'
     branches:
+      # Trigger the workflow on push to the master branch
       - master
   pull_request:
     branches:
+      # Trigger the workflow on pull request targeting the master branch
       - master
 
 env:


### PR DESCRIPTION
This [change](https://github.com/fbradyirl/openwrt-luci-rpc/pull/47/commits/f21f54dc4a75dc856ba1d4f73c2ad30e0407e2d3) described in https://github.com/fbradyirl/openwrt-luci-rpc/pull/47#issuecomment-803272577 disabled the triggering of the Github Actions workflow when pushing tags :facepalm: 