### PR TITLE
Add rst-linter pre-commit hook to prevent committing errors to HISTORY.rst

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/Lucas-C/pre-commit-hooks-markup
+  rev: v1.0.1
+  hooks:
+  - id: rst-linter
+    files: HISTORY.rst

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -141,5 +141,5 @@ History
 * Publish to pypi only once in github actions (#47)
 
 1.1.10 (2021-03-21)
-------------------
+-------------------
 * Also trigger the Github Actions on push of tags (#49)


### PR DESCRIPTION
Add `rst-linter` pre-commit hook to prevent committing changes to HISTORY.rst that will be rejected by the pypa/gh-action-pypi-publish Github Action like in https://github.com/fbradyirl/openwrt-luci-rpc/runs/2159124291?check_suite_focus=true#step:7:16