### PR TITLE
Add lower bound to version check, fixes #51, #52

### DIFF
--- a/openwrt_luci_rpc/utilities.py
+++ b/openwrt_luci_rpc/utilities.py
@@ -42,5 +42,5 @@ def get_hostname_from_dhcp(dhcp_result, mac):
 def is_legacy_version(owrt_version):
     return (
         "snapshot" not in owrt_version.public and
-        owrt_version < version.parse("18.06")
+        version.parse("18.06") > owrt_version >= version.parse("15.06")
     )


### PR DESCRIPTION
This fixes the version check against Turris routers without impacting compatibility with older versions of OpenWRT.
Tested against latest Turris Omnia.

Fixes #51, #52