### PR TITLE
Downgrade logging level for version detection

### DIFF
--- a/openwrt_luci_rpc/openwrt_luci_rpc.py
+++ b/openwrt_luci_rpc/openwrt_luci_rpc.py
@@ -114,7 +114,7 @@ class OpenWrtLuciRPC:
             self._refresh_token()
             return self._determine_if_legacy_version()
         except Exception:
-            log.error("Could not determine OpenWRT version, \
+            log.debug("Could not determine OpenWRT version, \
                          defaulting to version 18.06")
             self.owrt_version = version.parse("18.06")
 


### PR DESCRIPTION
It's not an error if the version could not be determined because it's just treated as being 18.06 - which is functional - anyway, so we log it as debug only.