### PR TITLE
Issue 60

### DIFF
--- a/openwrt_luci_rpc/utilities.py
+++ b/openwrt_luci_rpc/utilities.py
@@ -29,9 +29,10 @@ def get_hostname_from_dhcp(dhcp_result, mac):
                 if x['.type'] == 'host'
                 and 'mac' in x
                 and 'name' in x
-                and (( isinstance(x['mac'],list) and x['mac'][0].upper()==mac)
-                or (isinstance(x['mac'],str) and x['mac'].upper()==mac) )]
-
+                and ((isinstance(x['mac'], list)
+                      and x['mac'][0].upper() == mac)
+                or (isinstance(x['mac'], str)
+                    and x['mac'].upper() == mac))]
 
         if host:
             log.debug("DNS name lookup for mac {} "

--- a/openwrt_luci_rpc/utilities.py
+++ b/openwrt_luci_rpc/utilities.py
@@ -29,7 +29,9 @@ def get_hostname_from_dhcp(dhcp_result, mac):
                 if x['.type'] == 'host'
                 and 'mac' in x
                 and 'name' in x
-                and x['mac'].upper() == mac]
+                and (( isinstance(x['mac'],list) and x['mac'][0].upper()==mac)
+                or (isinstance(x['mac'],str) and x['mac'].upper()==mac) )]
+
 
         if host:
             log.debug("DNS name lookup for mac {} "

--- a/tests/test_openwrt_60.py
+++ b/tests/test_openwrt_60.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `openwrt_luci_rpc` package."""
+
+
+import unittest
+
+from openwrt_luci_rpc import utilities
+
+
+class TestOpenwrtLuciRPC(unittest.TestCase):
+    """Tests for `openwrt_luci_rpc` package."""
+
+    def setUp(self):
+        """Set up test fixtures, if any."""
+
+    def tearDown(self):
+        """Tear down test fixtures, if any."""
+
+    def test_get_hostname_from_dhcp_mac_list_formating(self):
+        """Test if lower case list of MAC match with Upper case."""
+
+        data = [{
+            ".name": "cfg07ee1",
+            ".type": "host",
+            "name": "imac-ethernet",
+            ".index": 4,
+            "mac": ["c8:2a:10:4a:10:dd"],
+            "dns": "1",
+            ".anonymous": True,
+            "ip": "192.168.1.124"
+        }]
+
+        data = utilities.get_hostname_from_dhcp(data, "C8:2A:10:4A:10:DD")
+        assert data is None
+
+    def test_get_hostname_from_dhcp_mac_string_formating(self):
+        """Test if lower case string of MAC match with Upper case."""
+
+        data = [{
+            ".name": "cfg07ee1",
+            ".type": "host",
+            "name": "imac-ethernet",
+            ".index": 4,
+            "mac": "c8:2a:10:4a:10:dd",
+            "dns": "1",
+            ".anonymous": True,
+            "ip": "192.168.1.124"
+        }]
+
+        data = utilities.get_hostname_from_dhcp(data, "C8:2A:10:4A:10:DD")
+        assert data is None


### PR DESCRIPTION
Fix for  Luci device tracker: AttributeError: 'list' object has no attribute 'upper' #60 
It seems that openwrt can now send a list or a string and this is not handled. Fix it.